### PR TITLE
Fixed Macro Overwriting

### DIFF
--- a/inc/astrokey.h
+++ b/inc/astrokey.h
@@ -18,7 +18,7 @@
 #define ASTROKEY_GET_MACRO 0x02
 
 // Switch configuration
-#define NUM_SWITCHES 2
+#define NUM_SWITCHES 5
 #define S0 P0_B0
 #define S1 P0_B1
 #define S2 P0_B2
@@ -41,12 +41,20 @@ typedef struct {
   uint8_t value;
 } Macro_TypeDef;
 
-#define MACRO_MAX_SIZE 10
-#define MACRO_MAX_KEYS 6
-#define MACRO_BYTES (MACRO_MAX_SIZE * sizeof(Macro_TypeDef))
+// User data flash
+#define USER_PAGE_SIZE  64
+#define USER_START_ADDR 0xF800
 
-#define BOOTLOADER_START_ADDR 0x1A00
-#define MACRO_FLASH_ADDR (BOOTLOADER_START_ADDR - (NUM_SWITCHES * MACRO_BYTES))
+// Number of pages per macro
+#define MACRO_PAGES 2
+// Number of bytes per macro
+#define MACRO_BYTES (MACRO_PAGES * USER_PAGE_SIZE)
+// Maximum number of actions in a macro
+#define MACRO_MAX_SIZE ((MACRO_BYTES) / sizeof(Macro_TypeDef))
+// Max number of keys simultaenously held by macro
+#define MACRO_MAX_KEYS 6
+
+#define MACRO_FLASH_ADDR USER_START_ADDR
 
 void saveMacro(Macro_TypeDef* macroData, uint8_t saveIndex);
 void loadMacro(Macro_TypeDef* macroData, uint8_t loadIndex);

--- a/src/descriptors.c
+++ b/src/descriptors.c
@@ -89,7 +89,7 @@ SI_SEGMENT_VARIABLE(deviceDesc[],
   64,                              // bMaxPacketSize
   USB_VENDOR_ID,                   // idVendor
   USB_PRODUCT_ID,                  // idProduct
-  htole16(0x0001),                 // bcdDevice
+  htole16(0x0002),                 // bcdDevice
   1,                               // iManufacturer
   2,                               // iProduct
   3,                               // iSerialNumber

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@
 #include "idle.h"
 #include "InitDevice.h"
 #include "astrokey.h"
+#include "EFM8UB1_FlashPrimitives.h"
 #include "EFM8UB1_FlashUtils.h"
 
 #include <stdint.h>
@@ -153,7 +154,7 @@ void stepMacro()
 void saveMacro(Macro_TypeDef* macroData, uint8_t saveIndex)
 {
   FLADDR flashAddr = MACRO_FLASH_ADDR + (saveIndex * MACRO_BYTES);
-  //FLASH_Clear(flashAddr, MACRO_BYTES);
+  FLASH_PageErase(MACRO_FLASH_ADDR + (saveIndex * MACRO_BYTES));
   FLASH_Write(flashAddr, (uint8_t*) macroData, MACRO_BYTES);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -74,8 +74,6 @@ Macro_TypeDef SI_SEG_XDATA tmpMacro[MACRO_MAX_SIZE];
 
 // The data of the current macro
 Macro_TypeDef SI_SEG_XDATA macro[MACRO_MAX_SIZE];
-// Number of actions in current macro
-uint8_t macroNumActions = 0;
 
 // Index of current macro running (i.e. 0 for 1st key, etc.)
 uint8_t macroIndex = NO_MACRO;
@@ -145,7 +143,7 @@ void stepMacro()
   keyReportSent = false;
 
   actionIndex++;
-  if (actionIndex == macroNumActions)
+  if (actionType == 0x00 || actionIndex == MACRO_MAX_SIZE)
   {
     macroIndex = NO_MACRO;
   }
@@ -153,29 +151,17 @@ void stepMacro()
 
 void saveMacro(Macro_TypeDef* macroData, uint8_t saveIndex)
 {
+  uint8_t i;
   FLADDR flashAddr = MACRO_FLASH_ADDR + (saveIndex * MACRO_BYTES);
-  FLASH_PageErase(MACRO_FLASH_ADDR + (saveIndex * MACRO_BYTES));
+  for (i = 0; i < MACRO_PAGES; i++)
+    FLASH_PageErase(flashAddr + (USER_PAGE_SIZE * i));
   FLASH_Write(flashAddr, (uint8_t*) macroData, MACRO_BYTES);
 }
 
 void loadMacro(Macro_TypeDef* macroData, uint8_t loadIndex)
 {
-  uint8_t i;
-
-
   FLADDR flashAddr = MACRO_FLASH_ADDR + (loadIndex * MACRO_BYTES);
   FLASH_Read((uint8_t *)macroData, flashAddr, MACRO_BYTES);
-
-  macroNumActions = MACRO_MAX_SIZE;
-
-  for (i = 0; i < MACRO_MAX_SIZE; i++)
-  {
-    if (macroData[i].actionType == 0)
-    {
-      macroNumActions = i;
-      break;
-    }
-  }
 }
 
 // Starts running a macro


### PR DESCRIPTION
Taking a close look at the datasheet revealed an extra 960 bytes of flash that exists to be used to store user data, so I moved macro storage to this section. Because I can now page align macros since the entirety of those pages is for macro storage, I was able to implement page clearing, allowing macros to be overwritten. This barely fit in the 8kB flash after some refactoring to save code size, leaving 30 bytes of free space between the program and the bootloader.